### PR TITLE
WIP: [#118479861] Prefix master password generation with a seed

### DIFF
--- a/jobs/rds-broker/spec
+++ b/jobs/rds-broker/spec
@@ -36,6 +36,8 @@ properties:
   rds-broker.db_prefix:
     description: "Prefix to add to RDS DB Identifiers"
     default: "cf"
+  rds-broker.master_password_seed:
+    description: "Secret seed to be used when generating the master RDS DB password"
   rds-broker.allow_user_provision_parameters:
     description: "Allow users to send arbitrary parameters on provision calls"
     default: false

--- a/jobs/rds-broker/templates/config/rds-config.json.erb
+++ b/jobs/rds-broker/templates/config/rds-config.json.erb
@@ -5,6 +5,7 @@
   "rds_config": {
     "region": "<%= p('rds-broker.aws_region') %>",
     "db_prefix": "<%= p('rds-broker.db_prefix') %>",
+    "master_password_seed": "<%= p('rds-broker.master_password_seed') %>",
     "allow_user_provision_parameters": <%= p('rds-broker.allow_user_provision_parameters') %>,
     "allow_user_update_parameters": <%= p('rds-broker.allow_user_update_parameters') %>,
     "allow_user_bind_parameters": <%= p('rds-broker.allow_user_bind_parameters') %>,


### PR DESCRIPTION
## What

In a previous version of rds-broker, if you know the service GUID for a database instance, you can  determine the master password. This should not be possible as this password is supposed to be secret.

In https://github.com/alphagov/paas-rds-broker/pull/7 we added a configuration variable master_password_seed which is added to the service GUID before hashing. This means that it's no longer possible to determine the master password from the instance_id alone.

This PR updates the spec and template to configure this option
## Dependency

Wait until https://github.com/alphagov/paas-rds-broker/pull/7  is merged, and then update the repo submodule in the last commit.
## How to test

The best approach is testing it by deploying this PR (???) in cloudfoundry.
## Post tasks

Once this PR is merged, tag the commit with the version 0.0.4 and remove the last commit of (???)
## Who?

Anyone but @keymon or @alext
