### PR TITLE
[#118479861] Use new, password generating RDS broker

### DIFF
--- a/jobs/rds-broker/spec
+++ b/jobs/rds-broker/spec
@@ -36,6 +36,8 @@ properties:
   rds-broker.db_prefix:
     description: "Prefix to add to RDS DB Identifiers"
     default: "cf"
+  rds-broker.master_password_seed:
+    description: "Secret seed to be used when generating the master RDS DB password"
   rds-broker.allow_user_provision_parameters:
     description: "Allow users to send arbitrary parameters on provision calls"
     default: false

--- a/jobs/rds-broker/spec
+++ b/jobs/rds-broker/spec
@@ -38,6 +38,8 @@ properties:
     default: "cf"
   rds-broker.master_password_seed:
     description: "Secret seed to be used when generating the master RDS DB password"
+  rds-broker.broker_name:
+    description: "Unique name of RDS broker, used to construct a tag for instance identification"
   rds-broker.allow_user_provision_parameters:
     description: "Allow users to send arbitrary parameters on provision calls"
     default: false

--- a/jobs/rds-broker/templates/config/rds-config.json.erb
+++ b/jobs/rds-broker/templates/config/rds-config.json.erb
@@ -5,6 +5,7 @@
   "rds_config": {
     "region": "<%= p('rds-broker.aws_region') %>",
     "db_prefix": "<%= p('rds-broker.db_prefix') %>",
+    "master_password_seed": "<%= p('rds-broker.master_password_seed') %>",
     "allow_user_provision_parameters": <%= p('rds-broker.allow_user_provision_parameters') %>,
     "allow_user_update_parameters": <%= p('rds-broker.allow_user_update_parameters') %>,
     "allow_user_bind_parameters": <%= p('rds-broker.allow_user_bind_parameters') %>,

--- a/jobs/rds-broker/templates/config/rds-config.json.erb
+++ b/jobs/rds-broker/templates/config/rds-config.json.erb
@@ -6,6 +6,7 @@
     "region": "<%= p('rds-broker.aws_region') %>",
     "db_prefix": "<%= p('rds-broker.db_prefix') %>",
     "master_password_seed": "<%= p('rds-broker.master_password_seed') %>",
+    "broker_name": "<%= p('rds-broker.broker_name') %>",
     "allow_user_provision_parameters": <%= p('rds-broker.allow_user_provision_parameters') %>,
     "allow_user_update_parameters": <%= p('rds-broker.allow_user_update_parameters') %>,
     "allow_user_bind_parameters": <%= p('rds-broker.allow_user_bind_parameters') %>,


### PR DESCRIPTION
### What

[Generating secure master password for Postgres Instances](https://www.pivotaltracker.com/n/projects/1275640/stories/118479861)

Use latest broker from https://github.com/alphagov/paas-rds-broker/pull/11. Add new properties into spec and config file templates to configure the new features.
### Testing

Deploy this release against existing environment. E.g. by using https://github.com/alphagov/paas-cf/pull/320. Observe new broker release being deployed. In the broker logs you can see that it tries to connect first, fails ping and updates password afterwards. After deployment, all tests should pass and everything should continue working as usual.
### Merging

This PR depends on https://github.com/alphagov/paas-rds-broker/pull/11. Once that has been merged, remove https://github.com/alphagov/paas-aws-broker-boshrelease/commit/a3a6bfd117fb9e40ff5853f94df70c0dd91cdf3e and add a new commit pointing the rds-broker [submodule](https://github.com/alphagov/paas-aws-broker-boshrelease/tree/master/src/github.com/alphagov) at the merge commit of  https://github.com/alphagov/paas-rds-broker/pull/11.
### Who

not @mtekel or @keymon or @saliceti 
