### PR TITLE
[#124720541] Send rds-broker logs to syslog

### DIFF
--- a/jobs/rds-broker/templates/bin/rds-broker-ctl.erb
+++ b/jobs/rds-broker/templates/bin/rds-broker-ctl.erb
@@ -16,8 +16,8 @@ case $1 in
     exec /var/vcap/packages/rds-broker/bin/paas-rds-broker \
       --config=${RDS_BROKER_CONF_DIR}/rds-config.json \
       --port=${RDS_BROKER_PORT} \
-      >>${RDS_BROKER_LOG_DIR}/${OUTPUT_LABEL}.stdout.log \
-      2>>${RDS_BROKER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log
+      > >(tee -a ${RDS_BROKER_LOG_DIR}/${OUTPUT_LABEL}.stdout.log | logger -t vcap.${OUTPUT_LABEL}.stdout) \
+      2> >(tee -a ${RDS_BROKER_LOG_DIR}/${OUTPUT_LABEL}.stderr.log | logger -t vcap.${OUTPUT_LABEL}.stderr)
     ;;
 
   stop)


### PR DESCRIPTION
[#124720541 Not all logs shipped to kibana/logsearch](https://www.pivotaltracker.com/n/projects/1275640/stories/124720541)
# What
## General justification

Several of the CF and Diego platform services send logs to the local syslog, tagged as `vcap.*`. . The [metron agent from loggregrator configures the local syslog to send the logs to metron](https://github.com/cloudfoundry/loggregator/blob/develop/jobs/metron_agent/spec#L29) so that later can be sent to a centralised logging service. 

In some cases it is the service application itself who sends the logs to syslog, but it seems to be a common pattern across CF and Diego services to [let the service log to stdout/stderr, and redirect that output to local files or syslog](https://github.com/cloudfoundry/diego-release/blob/develop/jobs/bbs/templates/bbs_as_vcap.erb#L91) using the [`logger` command](http://linux.die.net/man/1/logger). 

Not all the services implement this feature, and instead they only log to local files. In order to centralise all the logs, so we will add the logic required to send the logs of the missing services. 

We will implement the _log to stdout and redirect  to `logger` pattern_ whenever is possible.
## Implementation in rds-broker

We change the ctl script to redirect the output both to log files and logger. 
## How to review

The quickest is manually test the script in our running environment.
1. `bosh ssh rds_broker` and copy `/var/vcap/jobs/rds-broker/bin/rds-broker-ctl`
2. Restart `rds-broker` and check if the logs are being sent to syslog. 

```
curl  https://raw.githubusercontent.com/alphagov/paas-aws-broker-boshrelease/feature/124720541-support-syslog-logging/jobs/rds-broker/templates/bin/rds-broker-ctl.erb |  sudo tee /var/vcap/jobs/rds-broker/bin/rds-broker-ctl
sudo /var/vcap/bosh/bin/monit restart rds-broker

sudo grep vcap.rds-broker /var/log/syslog # check the logs are sent to syslog

tail  /var/vcap/sys/log/rds-broker/rds-broker.stdout.log # Logs should still be there

```
## Notes

We don't have `metron_agent` configured on the `rds_broker` vms, so the logs are not being shipped to the central logsearch. There will be another follow up PR to add metron agent and deploy this update once merged.
## Who?

Anyone but @richardc or @keymon 
