### PR TITLE
[#130188061] Rename release to rds-broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To use this BOSH release, first upload it to your BOSH:
 
 ```
 bosh target BOSH_HOST
-git clone https://github.com/alphagov/paas-aws-broker-boshrelease.git
+git clone https://github.com/alphagov/paas-rds-broker-boshrelease.git
 cd aws-broker-boshrelease
 bosh upload release releases/aws-broker/aws-broker-2.yml
 ```
@@ -57,8 +57,8 @@ You can deploy the AWS Service Broker using [Pivotal Ops Manager](https://networ
 Update the [handcraft.yml](metadata_parts/handcraft.yml) file with your modifications. Then, build the Pivotal tile:
 
 ```
-git clone https://github.com/alphagov/paas-aws-broker-boshrelease.git
-cd paas-aws-broker-boshrelease
+git clone https://github.com/alphagov/paas-rds-broker-boshrelease.git
+cd paas-rds-broker-boshrelease
 bundle install
 bundle exec vara build-pivotal .
 ```
@@ -86,11 +86,11 @@ Here are some ways *you* can contribute:
 * by writing specifications
 * by writing code (**no patch is too small**: fix typos, add comments, clean up inconsistent whitespace)
 * by refactoring code
-* by closing [issues](https://github.com/alphagov/paas-aws-broker-boshrelease/issues)
+* by closing [issues](https://github.com/alphagov/paas-rds-broker-boshrelease/issues)
 * by reviewing patches
 
 ### Submitting an Issue
-We use the [GitHub issue tracker](https://github.com/alphagov/paas-aws-broker-boshrelease/issues) to track bugs and features. Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. You can indicate support for an existing issue by voting it up. When submitting a bug report, please include a
+We use the [GitHub issue tracker](https://github.com/alphagov/paas-rds-broker-boshrelease/issues) to track bugs and features. Before submitting a bug report or feature request, check to make sure it hasn't already been submitted. You can indicate support for an existing issue by voting it up. When submitting a bug report, please include a
 [Gist](http://gist.github.com/) that includes a stack trace and any details that may be necessary to reproduce the bug,. Ideally, a bug report should include a pull request with failing specs.
 
 ### Submitting a Pull Request

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This is NOT presently a production ready AWS Service Broker BOSH release. This i
 
 ### AWS credentials and permissions
 
-This BOSH release requires an AWS user with some advanced privileges. Instead of using your primary AWS admin user, it is recommended to create a new AWS user (with the proper access keys), create an specific policy based on the [iam_policy.json](https://github.com/alphagov/paas-aws-broker-boshrelease/blob/master/iam_policy.json) file, and then attach the policy to the user.
+This BOSH release requires an AWS user with some advanced privileges. Instead of using your primary AWS admin user, it is recommended to create a new AWS user (with the proper access keys), create an specific policy based on the [iam_policy.json](iam_policy.json) file, and then attach the policy to the user.
 
 ### Using BOSH
 
@@ -32,7 +32,7 @@ bosh upload release releases/aws-broker/aws-broker-2.yml
 
 #### Create a BOSH deployment manifest
 
-Now create a deployment file (using the files at the [examples](https://github.com/alphagov/paas-aws-broker-boshrelease/blob/master/examples/) directory as a starting point).
+Now create a deployment file (using the files in the [examples](examples/) directory as a starting point).
 
 #### Deploy using the BOSH deployment manifest
 
@@ -54,7 +54,7 @@ You can deploy the AWS Service Broker using [Pivotal Ops Manager](https://networ
 
 ##### Build the Pivotal tile
 
-Update the [handcraft.yml](https://github.com/alphagov/paas-aws-broker-boshrelease/blob/master/metadata_parts/handcraft.yml) file with your modifications. Then, build the Pivotal tile:
+Update the [handcraft.yml](metadata_parts/handcraft.yml) file with your modifications. Then, build the Pivotal tile:
 
 ```
 git clone https://github.com/alphagov/paas-aws-broker-boshrelease.git
@@ -103,4 +103,4 @@ We use the [GitHub issue tracker](https://github.com/alphagov/paas-aws-broker-bo
 
 ## Copyright
 
-Copyright (c) 2015 Pivotal Software, Inc & 2016 [Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service). See [LICENSE](https://github.com/alphagov/paas-aws-broker-boshrelease/blob/master/LICENSE) for details.
+Copyright (c) 2015 Pivotal Software, Inc & 2016 [Government Digital Service](https://www.gov.uk/government/organisations/government-digital-service). See [LICENSE](LICENSE) for details.

--- a/config/final.yml
+++ b/config/final.yml
@@ -1,5 +1,5 @@
 ---
-final_name: aws-broker
+final_name: rds-broker
 blobstore:
   provider: s3
   options:

--- a/examples/aws-broker-bosh-lite.yml
+++ b/examples/aws-broker-bosh-lite.yml
@@ -48,17 +48,6 @@ resource_pools:
     cloud_properties: {}
 
 jobs:
-  - name: cloudformation-broker
-    templates:
-      - name: cloudformation-broker
-    instances: 1
-    resource_pool: default
-    networks:
-      - name: default
-        default: [dns, gateway]
-        static_ips:
-          - 10.244.0.2
-
   - name: rds-broker
     templates:
       - name: rds-broker
@@ -69,17 +58,6 @@ jobs:
         default: [dns, gateway]
         static_ips:
           - 10.244.0.3
-
-  - name: sqs-broker
-    templates:
-      - name: sqs-broker
-    instances: 1
-    resource_pool: default
-    networks:
-      - name: default
-        default: [dns, gateway]
-        static_ips:
-          - 10.244.0.4
 
 properties:
   cloudformation-broker:

--- a/examples/rds-broker-bosh-lite.yml
+++ b/examples/rds-broker-bosh-lite.yml
@@ -1,5 +1,5 @@
 <%
-deployment_name = "aws-broker"
+deployment_name = "rds-broker"
 director_uuid = "CHANGE-ME"
 aws_access_key_id = "CHANGE-ME"
 aws_secret_access_key = "CHANGE-ME"
@@ -10,7 +10,7 @@ name: <%= deployment_name %>
 director_uuid: <%= director_uuid %>
 
 releases:
-  - name: aws-broker
+  - name: rds-broker
     version: latest
 
 compilation:


### PR DESCRIPTION
## What

This updates this repo so that the name of the boshrelease is rds-broker. This is to reflect the fact that this now only packages up the RDS broker, and not a number of AWS service brokers.

Once this is merged, I intend to rename this repository to `paas-rds-broker-boshrelease`. This is safe to do because [Github sets up redirects for everything](https://help.github.com/articles/renaming-a-repository/)

## How to review

Code review - make sure it all looks sensible.

## Who can review

Anyone but @henrytk or myself.