### PR TITLE
[#153253386] Fix package dependency types

### DIFF
--- a/packages/bosh-helpers/spec
+++ b/packages/bosh-helpers/spec
@@ -1,5 +1,5 @@
 ---
 name: bosh-helpers
-dependencies: {}
+dependencies: []
 files:
   - bosh-helpers/*

--- a/packages/golang/spec
+++ b/packages/golang/spec
@@ -1,5 +1,5 @@
 ---
 name: golang
-dependencies: {}
+dependencies: []
 files:
   - golang/go1.8.linux-amd64.tar.gz


### PR DESCRIPTION
## What

Empty dependency fields were being given as empty dictionaries rather than empty arrays.

## How to review

See if the CI passes.

## Who can review

Not @46bit