### PR TITLE
[#155625342]  Add rds-broker-cron job

### DIFF
--- a/jobs/rds-broker-cron/monit
+++ b/jobs/rds-broker-cron/monit
@@ -1,0 +1,9 @@
+<% if spec.bootstrap %>
+check process rds-broker-cron
+  with pidfile /var/vcap/sys/run/rds-broker-cron/rds-broker-cron.pid
+  start program "/var/vcap/packages/bosh-helpers/monit_debugger rds-broker-cron-ctl '/var/vcap/jobs/rds-broker-cron/bin/rds-broker-cron-ctl start'"
+  stop program "/var/vcap/packages/bosh-helpers/monit_debugger rds-broker-cron-ctl '/var/vcap/jobs/rds-broker-cron/bin/rds-broker-cron-ctl stop'"
+  group vcap
+<% else %>
+# Job disabled on VM index > 0.
+<% end %>

--- a/jobs/rds-broker-cron/spec
+++ b/jobs/rds-broker-cron/spec
@@ -1,0 +1,31 @@
+---
+name: rds-broker-cron
+
+packages:
+  - bosh-helpers
+  - rds-broker
+
+templates:
+  bin/job_properties.sh.erb: bin/job_properties.sh
+  bin/rds-broker-cron-ctl.erb: bin/rds-broker-cron-ctl
+  config/rds-config.json.erb: config/rds-config.json
+
+properties:
+  rds-broker.log_level:
+    description: "Log Level (DEBUG, INFO, ERROR, FATAL)"
+    default: "DEBUG"
+  rds-broker.aws_access_key_id:
+    description: "AWS Access Key ID"
+  rds-broker.aws_secret_access_key:
+    description: "AWS Secret Access Key"
+  rds-broker.aws_region:
+    description: "AWS RDS Region"
+    default: "us-east-1"
+  rds-broker.broker_name:
+    description: "Unique name of RDS broker, used to filter which old snapshots do delete (matching the `Broker Name` tag)"
+  rds-broker.cron_schedule:
+    description: "Schedule for cron jobs. A crontab-like expression with seconds precision (e.g. '0 0 * * * *' or '@hourly'), with fields: 'second minute hour dom month dow'"
+    default: "@hourly"
+  rds-broker.keep_snapshots_for_days:
+    description: "Number of days to keep old RDS snapshots for"
+    default: 35

--- a/jobs/rds-broker-cron/templates/bin/job_properties.sh.erb
+++ b/jobs/rds-broker-cron/templates/bin/job_properties.sh.erb
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+#
+# RDS Broker Cron properties
+#
+
+# Directory to store the RDS Broker Cron configuration files
+export RDS_BROKER_CRON_CONF_DIR=${JOB_DIR}/config
+
+# Directory to store the RDS Broker Cron log files
+export RDS_BROKER_CRON_LOG_DIR=${LOG_DIR}
+
+# Directory to store the RDS Broker Cron process IDs
+export RDS_BROKER_CRON_PID_DIR=${RUN_DIR}
+
+# Directory to store the RDS Broker Cron data files
+export RDS_BROKER_CRON_STORE_DIR=${STORE_DIR}
+
+# Directory to store the RDS Broker Cron temp files
+export RDS_BROKER_CRON_TMP_DIR=${TMP_DIR}
+
+# AWS Access Key ID
+export AWS_ACCESS_KEY_ID="<%= p('rds-broker.aws_access_key_id') %>"
+
+# AWS Secret Access Key
+export AWS_SECRET_ACCESS_KEY="<%= p('rds-broker.aws_secret_access_key') %>"

--- a/jobs/rds-broker-cron/templates/bin/rds-broker-cron-ctl.erb
+++ b/jobs/rds-broker-cron/templates/bin/rds-broker-cron-ctl.erb
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup common env vars and folders
+source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'rds-broker-cron'
+export RDS_BROKER_CRON_PID_FILE=${RDS_BROKER_CRON_PID_DIR}/rds-broker-cron.pid
+
+case $1 in
+
+  start)
+    pid_guard ${RDS_BROKER_CRON_PID_FILE} ${JOB_NAME}
+    echo $$ > ${RDS_BROKER_CRON_PID_FILE}
+
+    # Start RDS Broker Cron service
+    exec /var/vcap/packages/rds-broker/bin/paas-rds-broker -cron \
+      --config=${RDS_BROKER_CRON_CONF_DIR}/rds-config.json \
+      > >(tee -a ${RDS_BROKER_CRON_LOG_DIR}/${OUTPUT_LABEL}.stdout.log | logger -t vcap.${OUTPUT_LABEL}.stdout) \
+      2> >(tee -a ${RDS_BROKER_CRON_LOG_DIR}/${OUTPUT_LABEL}.stderr.log | logger -t vcap.${OUTPUT_LABEL}.stderr)
+    ;;
+
+  stop)
+    # Stop RDS Broker Cron service
+    kill_and_wait ${RDS_BROKER_CRON_PID_FILE}
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
+
+esac
+exit 0

--- a/jobs/rds-broker-cron/templates/config/rds-config.json.erb
+++ b/jobs/rds-broker-cron/templates/config/rds-config.json.erb
@@ -1,0 +1,9 @@
+{
+  "log_level": "<%= p('rds-broker.log_level') %>",
+  "cron_schedule": "<%= p('rds-broker.cron_schedule') %>",
+  "keep_snapshots_for_days": <%= p('rds-broker.keep_snapshots_for_days') %>,
+  "rds_config": {
+    "region": "<%= p('rds-broker.aws_region') %>",
+    "broker_name": "<%= p('rds-broker.broker_name') %>"
+  }
+}


### PR DESCRIPTION
## What

We added a cron job process to the RDS broker to clean up old RDS snapshots. We only delete manual snapshots which have a matching Broker Name AWS tag.

We define a separate job for it so it can run as a separate process.

The cron process will only run on the first instance.

❗️ This PR contains a temporary commit which needs to be replace with the final revision of the paas-rds-broker repo.

## How to review

Review as part of https://github.com/alphagov/paas-cf/pull/1285

## Who can review

Not me.