### PR TITLE
[#157084165] Add rds-metric-collector to the release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/github.com/alphagov/paas-rds-broker"]
 	path = src/github.com/alphagov/paas-rds-broker
 	url = https://github.com/alphagov/paas-rds-broker.git
+[submodule "src/github.com/alphagov/paas-rds-metric-collector"]
+	path = src/github.com/alphagov/paas-rds-metric-collector
+	url = https://github.com/alphagov/paas-rds-metric-collector.git

--- a/jobs/rds-metric-collector/monit
+++ b/jobs/rds-metric-collector/monit
@@ -1,0 +1,5 @@
+check process rds-metric-collector
+  with pidfile /var/vcap/sys/run/rds-metric-collector/rds-metric-collector.pid
+  start program "/var/vcap/packages/bosh-helpers/monit_debugger rds-metric-collector-ctl '/var/vcap/jobs/rds-metric-collector/bin/rds-metric-collector-ctl start'"
+  stop program "/var/vcap/packages/bosh-helpers/monit_debugger rds-metric-collector-ctl '/var/vcap/jobs/rds-metric-collector/bin/rds-metric-collector-ctl stop'"
+  group vcap

--- a/jobs/rds-metric-collector/spec
+++ b/jobs/rds-metric-collector/spec
@@ -1,0 +1,48 @@
+---
+name: rds-metric-collector
+
+packages:
+  - bosh-helpers
+  - rds-metric-collector
+
+templates:
+  bin/job_properties.sh.erb: bin/job_properties.sh
+  bin/rds-metric-collector-ctl.erb: bin/rds-metric-collector-ctl
+  config/config.json.erb: config/config.json
+
+properties:
+  rds-metric-collector.log_level:
+    description: "RDS Metric Collector Log Level (DEBUG, INFO, ERROR, FATAL)"
+    default: "DEBUG"
+  rds-metric-collector.aws.aws_access_key_id:
+    description: "AWS Access Key ID"
+  rds-metric-collector.aws.aws_secret_access_key:
+    description: "AWS Secret Access Key"
+  rds-metric-collector.aws.aws_region:
+    description: "AWS RDS Region"
+    default: "us-east-1"
+  rds-metric-collector.rds-broker.broker_name:
+    description: "Unique name of RDS broker, used to construct a tag for instance identification. Should be the same as rds-broker.db_prefix."
+  rds-metric-collector.rds-broker.db_prefix:
+    description: "Prefix to add to RDS DB Identifiers. Should be the same as rds-broker.db_prefix."
+    default: "cf"
+  rds-metric-collector.rds-broker.master_password_seed:
+    description: "Secret seed to be used when generating the master RDS DB password. Should be the same as rds-broker.db_prefix."
+  rds-metric-collector.scheduler.instance_refresh_interval:
+    description: "Interval to check for new provisioned instances"
+    default: 300
+  rds-metric-collector.scheduler.metrics_collector_interval:
+    description: "Interval to query for metrics in each intance"
+    default: 60
+  rds-metric-collector.loggregator.url:
+    description: "URL to loggregator ingress endpoint, usually metron agent."
+    default: localhost:3458
+  rds-metric-collector.loggregator.ca_cert:
+    description: "CA Cert for the loggregator ingress endpoint"
+    default: "/var/vcap/jobs/metron_agent/config/certs/loggregator_ca.crt"
+  rds-metric-collector.loggregator.client_cert:
+    description: "Client certificate for loggregator ingress traffic"
+    default: "/var/vcap/jobs/metron_agent/config/certs/metron_agent.crt"
+  rds-metric-collector.loggregator.client_key:
+    description: "Client certificate key for loggregator ingress traffic"
+    default: "/var/vcap/jobs/metron_agent/config/certs/metron_agent.key"

--- a/jobs/rds-metric-collector/templates/bin/job_properties.sh.erb
+++ b/jobs/rds-metric-collector/templates/bin/job_properties.sh.erb
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+#
+# RDS Metric Collector properties
+#
+
+# Directory to store the RDS Metric Collector configuration files
+export RDS_METRIC_COLLECTOR_CONF_DIR=${JOB_DIR}/config
+
+# Directory to store the RDS Metric Collector log files
+export RDS_METRIC_COLLECTOR_LOG_DIR=${LOG_DIR}
+
+# Directory to store the RDS Metric Collector process IDs
+export RDS_METRIC_COLLECTOR_PID_DIR=${RUN_DIR}
+
+# Directory to store the RDS Metric Collector data files
+export RDS_METRIC_COLLECTOR_STORE_DIR=${STORE_DIR}
+
+# Directory to store the RDS Metric Collector temp files
+export RDS_METRIC_COLLECTOR_TMP_DIR=${TMP_DIR}
+
+<%- if_p('metric-collector.aws.aws_access_key_id') { |x| %>
+# AWS Access Key ID
+export AWS_ACCESS_KEY_ID="<%= p('rds-metric-collector.aws.aws_access_key_id') %>"
+
+# AWS Secret Access Key
+export AWS_SECRET_ACCESS_KEY="<%= p('rds-metric-collector.aws.aws_secret_access_key') %>"
+<%- } %>

--- a/jobs/rds-metric-collector/templates/bin/rds-metric-collector-ctl.erb
+++ b/jobs/rds-metric-collector/templates/bin/rds-metric-collector-ctl.erb
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e # exit immediately if a simple command exits with a non-zero status
+
+# Setup common env vars and folders
+source /var/vcap/packages/bosh-helpers/ctl_setup.sh 'rds-metric-collector'
+export RDS_METRIC_COLLECTOR_PID_FILE=${RDS_METRIC_COLLECTOR_PID_DIR}/rds-metric-collector.pid
+
+case $1 in
+
+  start)
+    pid_guard ${RDS_METRIC_COLLECTOR_PID_FILE} ${JOB_NAME}
+    echo $$ > ${RDS_METRIC_COLLECTOR_PID_FILE}
+
+    # Start RDS Metric Collector service
+    exec /var/vcap/packages/rds-metric-collector/bin/paas-rds-metric-collector \
+      -config=${RDS_METRIC_COLLECTOR_CONF_DIR}/config.json \
+      > >(tee -a ${RDS_METRIC_COLLECTOR_LOG_DIR}/${OUTPUT_LABEL}.stdout.log | logger -t vcap.${OUTPUT_LABEL}.stdout) \
+      2> >(tee -a ${RDS_METRIC_COLLECTOR_LOG_DIR}/${OUTPUT_LABEL}.stderr.log | logger -t vcap.${OUTPUT_LABEL}.stderr)
+    ;;
+
+  stop)
+    # Stop RDS Metric Collector service
+    kill_and_wait ${RDS_METRIC_COLLECTOR_PID_FILE}
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop}"
+    exit 1
+    ;;
+
+esac
+exit 0

--- a/jobs/rds-metric-collector/templates/config/config.json.erb
+++ b/jobs/rds-metric-collector/templates/config/config.json.erb
@@ -1,0 +1,21 @@
+{
+  "log_level": "<%= p('rds-metric-collector.log_level') %>",
+  "aws": {
+    "region": "<%= p('rds-metric-collector.aws.aws_region') %>"
+  },
+  "rds_broker": {
+    "broker_name": "<%= p('rds-metric-collector.rds-broker.broker_name') %>",
+    "db_prefix": "<%= p('rds-metric-collector.rds-broker.db_prefix') %>",
+    "master_password_seed": "<%= p('rds-metric-collector.rds-broker.master_password_seed') %>"
+  },
+  "scheduler": {
+    "instance_refresh_interval": <%= p('rds-metric-collector.scheduler.instance_refresh_interval') %>,
+    "metrics_collector_interval": <%= p('rds-metric-collector.scheduler.metrics_collector_interval') %>
+  },
+  "loggregator_emitter": {
+      "url": "<%= p('rds-metric-collector.loggregator.url') %>",
+      "ca_cert": "<%= p('rds-metric-collector.loggregator.ca_cert') %>",
+      "client_cert": "<%= p('rds-metric-collector.loggregator.client_cert') %>",
+      "client_key": "<%= p('rds-metric-collector.loggregator.client_key') %>"
+  }
+}

--- a/packages/rds-metric-collector/packaging
+++ b/packages/rds-metric-collector/packaging
@@ -1,0 +1,17 @@
+set -e # exit immediately if a simple command exits with a non-zero status
+set -u # report the usage of uninitialized variables
+
+# Set Golang dependency
+export GOROOT=$(readlink -nf /var/vcap/packages/golang)
+export PATH=${GOROOT}/bin:${PATH}
+
+# Build AWS RDS Metric Collector package
+echo "Building RDS Metric Collector..."
+PACKAGE_NAME=github.com/alphagov/paas-rds-metric-collector
+mkdir -p ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
+cp -a ${BOSH_COMPILE_TARGET}/${PACKAGE_NAME}/* ${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}
+export GOPATH=${BOSH_INSTALL_TARGET}:${BOSH_INSTALL_TARGET}/src/${PACKAGE_NAME}/Godeps/_workspace
+go install ${PACKAGE_NAME}
+
+# Clean up pkg artifacts
+rm -rf ${BOSH_INSTALL_TARGET}/pkg

--- a/packages/rds-metric-collector/spec
+++ b/packages/rds-metric-collector/spec
@@ -1,0 +1,6 @@
+---
+name: rds-metric-collector
+dependencies:
+  - golang
+files:
+  - github.com/alphagov/paas-rds-metric-collector/**/*


### PR DESCRIPTION
What?
-----

We want to be able to deploy the rds-metric-collector service that would
peridically query metrics from the RDS broker instances and send them
to the loggregator stack.

In order for this service to work we need:
 - Deploy with the rds-broker, as it needs AWS credentials to find out the instances .
 - Also access to the psql port
 - Access to a metron agent to send the metrics. That metron agent might also need consul to discover the dopplers.

Dependencies
----------------
 - https://github.com/alphagov/paas-rds-metric-collector/pull/1
 - https://github.com/alphagov/paas-cf/pull/1385

**IMPORTANT**: Update the submodule in the WIP commit once https://github.com/alphagov/paas-rds-metric-collector/pull/1 has been merged

How to review?
------------

Review with https://github.com/alphagov/paas-cf/pull/1385


Who?
----

Anyone but @keymon or @leeporte