### PR TITLE
Make AWS access keys optional

### DIFF
--- a/jobs/rds-broker-cron/templates/bin/job_properties.sh.erb
+++ b/jobs/rds-broker-cron/templates/bin/job_properties.sh.erb
@@ -19,8 +19,12 @@ export RDS_BROKER_CRON_STORE_DIR=${STORE_DIR}
 # Directory to store the RDS Broker Cron temp files
 export RDS_BROKER_CRON_TMP_DIR=${TMP_DIR}
 
+<%- if_p('rds-broker.aws_access_key_id') do |access_key| %>
 # AWS Access Key ID
-export AWS_ACCESS_KEY_ID="<%= p('rds-broker.aws_access_key_id') %>"
+export AWS_ACCESS_KEY_ID="<%= access_key %>"
+<%- end %>
 
+<%- if_p('rds-broker.aws_secret_access_key') do |secret_key| %>
 # AWS Secret Access Key
-export AWS_SECRET_ACCESS_KEY="<%= p('rds-broker.aws_secret_access_key') %>"
+export AWS_SECRET_ACCESS_KEY="<%= secret_key %>"
+<%- end %>

--- a/jobs/rds-broker/templates/bin/job_properties.sh.erb
+++ b/jobs/rds-broker/templates/bin/job_properties.sh.erb
@@ -22,8 +22,12 @@ export RDS_BROKER_TMP_DIR=${TMP_DIR}
 # Broker Listen Port
 export RDS_BROKER_PORT="<%= p('rds-broker.port') %>"
 
+<%- if_p('rds-broker.aws_access_key_id') do |access_key| %>
 # AWS Access Key ID
-export AWS_ACCESS_KEY_ID="<%= p('rds-broker.aws_access_key_id') %>"
+export AWS_ACCESS_KEY_ID="<%= access_key %>"
+<%- end %>
 
+<%- if_p('rds-broker.aws_secret_access_key') do |secret_key| %>
 # AWS Secret Access Key
-export AWS_SECRET_ACCESS_KEY="<%= p('rds-broker.aws_secret_access_key') %>"
+export AWS_SECRET_ACCESS_KEY="<%= secret_key %>"
+<%- end %>

--- a/jobs/rds-metric-collector/templates/bin/job_properties.sh.erb
+++ b/jobs/rds-metric-collector/templates/bin/job_properties.sh.erb
@@ -19,10 +19,12 @@ export RDS_METRIC_COLLECTOR_STORE_DIR=${STORE_DIR}
 # Directory to store the RDS Metric Collector temp files
 export RDS_METRIC_COLLECTOR_TMP_DIR=${TMP_DIR}
 
-<%- if_p('metric-collector.aws.aws_access_key_id') { |x| %>
+<%- if_p('rds-metric-collector.aws.aws_access_key_id') do |access_key| %>
 # AWS Access Key ID
-export AWS_ACCESS_KEY_ID="<%= p('rds-metric-collector.aws.aws_access_key_id') %>"
+export AWS_ACCESS_KEY_ID="<%= access_key %>"
+<%- end %>
 
+<%- if_p('rds-metric-collector.aws.aws_secret_access_key') do |secret_key| %>
 # AWS Secret Access Key
-export AWS_SECRET_ACCESS_KEY="<%= p('rds-metric-collector.aws.aws_secret_access_key') %>"
-<%- } %>
+export AWS_SECRET_ACCESS_KEY="<%= secret_key %>"
+<%- end %>


### PR DESCRIPTION
## What

This is a refresh of #55 that makes AWS creds optional as they're not needed when using IAM instance profiles. I've opened this one to tidy up the generated config files (to omit the comments when the keys aren't present), and to also fix an issue in the newly added rds-metrics-colector job.

## How to review

Code review is probably enough.  I've tested this release in my dev environment, and it deployed correctly, and all the tests passed. I also added some dummy access keys to verify that they get written to the config files correctly.

## Who can review

Not me.