### PR TITLE
[#SUPPORT] Set metrics-collector default log level to INFO

### DIFF
--- a/jobs/rds-metric-collector/spec
+++ b/jobs/rds-metric-collector/spec
@@ -13,7 +13,7 @@ templates:
 properties:
   rds-metric-collector.log_level:
     description: "RDS Metric Collector Log Level (DEBUG, INFO, ERROR, FATAL)"
-    default: "DEBUG"
+    default: "INFO"
   rds-metric-collector.aws.aws_access_key_id:
     description: "AWS Access Key ID"
   rds-metric-collector.aws.aws_secret_access_key:


### PR DESCRIPTION
What?
----------

We are logging too much because it is set to debug

How to review?
-------
code review

Who?
---
Anyone