### PR TITLE
#158938536 Pass certs and keys directly as strings instead of paths

### DIFF
--- a/jobs/rds-metric-collector/spec
+++ b/jobs/rds-metric-collector/spec
@@ -9,6 +9,9 @@ templates:
   bin/job_properties.sh.erb: bin/job_properties.sh
   bin/rds-metric-collector-ctl.erb: bin/rds-metric-collector-ctl
   config/config.json.erb: config/config.json
+  config/loggregator.ca_cert.crt.erb: config/loggregator.ca_cert.crt
+  config/loggregator.client_cert.crt.erb: config/loggregator.client_cert.crt
+  config/loggregator.client_key.key.erb: config/loggregator.client_key.key
 
 properties:
   rds-metric-collector.log_level:
@@ -38,11 +41,8 @@ properties:
     description: "URL to loggregator ingress endpoint, usually metron agent."
     default: localhost:3458
   rds-metric-collector.loggregator.ca_cert:
-    description: "CA Cert for the loggregator ingress endpoint"
-    default: "/var/vcap/jobs/metron_agent/config/certs/loggregator_ca.crt"
+    description: "CA Cert for the loggregator ingress endpoint as a string"
   rds-metric-collector.loggregator.client_cert:
-    description: "Client certificate for loggregator ingress traffic"
-    default: "/var/vcap/jobs/metron_agent/config/certs/metron_agent.crt"
+    description: "Client certificate for loggregator ingress traffic as a string"
   rds-metric-collector.loggregator.client_key:
-    description: "Client certificate key for loggregator ingress traffic"
-    default: "/var/vcap/jobs/metron_agent/config/certs/metron_agent.key"
+    description: "Client certificate key for loggregator ingress traffic as a string"

--- a/jobs/rds-metric-collector/templates/config/config.json.erb
+++ b/jobs/rds-metric-collector/templates/config/config.json.erb
@@ -14,8 +14,8 @@
   },
   "loggregator_emitter": {
       "url": "<%= p('rds-metric-collector.loggregator.url') %>",
-      "ca_cert": "<%= p('rds-metric-collector.loggregator.ca_cert') %>",
-      "client_cert": "<%= p('rds-metric-collector.loggregator.client_cert') %>",
-      "client_key": "<%= p('rds-metric-collector.loggregator.client_key') %>"
+      "ca_cert": "/var/vcap/jobs/rds-metric-collector/config/loggregator.ca_cert.crt",
+      "client_cert": "/var/vcap/jobs/rds-metric-collector/config/loggregator.client_cert.crt",
+      "client_key": "/var/vcap/jobs/rds-metric-collector/config/loggregator.client_key.key"
   }
 }

--- a/jobs/rds-metric-collector/templates/config/loggregator.ca_cert.crt.erb
+++ b/jobs/rds-metric-collector/templates/config/loggregator.ca_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('rds-metric-collector.loggregator.ca_cert') %>

--- a/jobs/rds-metric-collector/templates/config/loggregator.client_cert.crt.erb
+++ b/jobs/rds-metric-collector/templates/config/loggregator.client_cert.crt.erb
@@ -1,0 +1,2 @@
+<%= p('rds-metric-collector.loggregator.client_cert') %>
+

--- a/jobs/rds-metric-collector/templates/config/loggregator.client_key.key.erb
+++ b/jobs/rds-metric-collector/templates/config/loggregator.client_key.key.erb
@@ -1,0 +1,2 @@
+<%= p('rds-metric-collector.loggregator.client_key') %>
+


### PR DESCRIPTION
It's a bad practice to refer directly to files in other releases since
you might end up with releases in different containers which don't have
access to each others file systems.

Instead we can pass the content of the file directly and create the
certs and keys with trivial templates. We can then hardcode the paths of
these files in config.json.