### PR TITLE
WIP: Run only one instance of the metrics collector

### DIFF
--- a/jobs/rds-metric-collector/monit
+++ b/jobs/rds-metric-collector/monit
@@ -1,5 +1,7 @@
+<% if spec.bootstrap %>
 check process rds-metric-collector
   with pidfile /var/vcap/sys/run/rds-metric-collector/rds-metric-collector.pid
   start program "/var/vcap/packages/bosh-helpers/monit_debugger rds-metric-collector-ctl '/var/vcap/jobs/rds-metric-collector/bin/rds-metric-collector-ctl start'"
   stop program "/var/vcap/packages/bosh-helpers/monit_debugger rds-metric-collector-ctl '/var/vcap/jobs/rds-metric-collector/bin/rds-metric-collector-ctl stop'"
   group vcap
+<% end %>


### PR DESCRIPTION
This stops duplicate metrics being sent.