### PR TITLE
[#158333555] Configure Locket credentials for rds-metric-collector

### DIFF
--- a/jobs/rds-metric-collector/spec
+++ b/jobs/rds-metric-collector/spec
@@ -12,6 +12,9 @@ templates:
   config/loggregator.ca_cert.crt.erb: config/loggregator.ca_cert.crt
   config/loggregator.client_cert.crt.erb: config/loggregator.client_cert.crt
   config/loggregator.client_key.key.erb: config/loggregator.client_key.key
+  config/locket.ca_cert.crt.erb: config/locket.ca_cert.crt
+  config/locket.client_cert.crt.erb: config/locket.client_cert.crt
+  config/locket.client_key.key.erb: config/locket.client_key.key
 
 properties:
   rds-metric-collector.log_level:
@@ -46,3 +49,12 @@ properties:
     description: "Client certificate for loggregator ingress traffic as a string"
   rds-metric-collector.loggregator.client_key:
     description: "Client certificate key for loggregator ingress traffic as a string"
+  rds-metric-collector.locket.api_location:
+    description: "The host and port for the Locket server"
+    example: "127.0.0.1:8891"
+  rds-metric-collector.locket.ca_cert:
+    description: "A PEM formatted certificate of a CA the Locket client will trust"
+  rds-metric-collector.locket.client_cert:
+    description: "A PEM formatted certificate used for client connections to the Locket server"
+  rds-metric-collector.locket.client_key:
+    description: "A PEM formatted key used for client connections to the Locket server"

--- a/jobs/rds-metric-collector/templates/config/config.json.erb
+++ b/jobs/rds-metric-collector/templates/config/config.json.erb
@@ -17,5 +17,9 @@
       "ca_cert": "/var/vcap/jobs/rds-metric-collector/config/loggregator.ca_cert.crt",
       "client_cert": "/var/vcap/jobs/rds-metric-collector/config/loggregator.client_cert.crt",
       "client_key": "/var/vcap/jobs/rds-metric-collector/config/loggregator.client_key.key"
-  }
+  },
+  "locket_address": "<%= p('rds-metric-collector.locket.api_location') %>",
+  "locket_ca_cert_file": "/var/vcap/jobs/rds-metric-collector/config/locket.ca_cert.crt",
+  "locket_client_cert_file": "/var/vcap/jobs/rds-metric-collector/config/locket.client_cert.crt",
+  "locket_client_key_file": "/var/vcap/jobs/rds-metric-collector/config/locket.client_key.key"
 }

--- a/jobs/rds-metric-collector/templates/config/locket.ca_cert.crt.erb
+++ b/jobs/rds-metric-collector/templates/config/locket.ca_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('rds-metric-collector.locket.ca_cert') %>

--- a/jobs/rds-metric-collector/templates/config/locket.client_cert.crt.erb
+++ b/jobs/rds-metric-collector/templates/config/locket.client_cert.crt.erb
@@ -1,0 +1,1 @@
+<%= p('rds-metric-collector.locket.client_cert') %>

--- a/jobs/rds-metric-collector/templates/config/locket.client_key.key.erb
+++ b/jobs/rds-metric-collector/templates/config/locket.client_key.key.erb
@@ -1,0 +1,1 @@
+<%= p('rds-metric-collector.locket.client_key') %>


### PR DESCRIPTION
## What

Update the RDS Metric Collector.

This version includes https://github.com/alphagov/paas-rds-metric-collector/pull/7, which stops the duplication of metrics.

## How to review

* ⚠️ merge https://github.com/alphagov/paas-rds-metric-collector/pull/7
* replace the temporary commit. It should submodule the collector using the tag from the build CI: https://concourse.build.ci.cloudpipeline.digital/teams/main/pipelines/rds-metric-collector/jobs/tag-releases

You can deploy as part of https://github.com/alphagov/paas-cf/pull/1462

## Who

Anyone but me or @richardTowers 